### PR TITLE
BluParser.ParseAbsoluteUri fix for Xamarin.Android

### DIFF
--- a/src/Blu4Net/BluParser.cs
+++ b/src/Blu4Net/BluParser.cs
@@ -10,7 +10,7 @@ namespace Blu4Net
     {
         public static Uri ParseAbsoluteUri(string value, Uri baseUri)
         {
-            if (!string.IsNullOrEmpty(value) && Uri.TryCreate(value, UriKind.RelativeOrAbsolute, out var uri))
+            if (!string.IsNullOrEmpty(value) && Uri.TryCreate(value, value?.StartsWith("/") == true ? UriKind.Relative : UriKind.RelativeOrAbsolute, out var uri))
             {
                 if (uri.IsAbsoluteUri)
                 {


### PR DESCRIPTION
Local workarounds (recommended) as described on this page:

https://www.mono-project.com/docs/faq/known-issues/urikind-relativeorabsolute/

To make this code work on Xamarin.Android.