### PR TITLE
Added PlayURL() to the MusicBrowser

### DIFF
--- a/src/Blu4Net/Channel/AddSongResponse.cs
+++ b/src/Blu4Net/Channel/AddSongResponse.cs
@@ -1,0 +1,22 @@
+﻿using System.Xml.Serialization;
+
+namespace Blu4Net.Channel
+{
+    [XmlRoot("addsong")]
+    public class AddSongResponse : LoadedResponse
+    {
+        [XmlAttribute("id")]
+        public int ID;
+
+        [XmlAttribute("count")]
+        public int Count;
+
+        [XmlAttribute("length")]
+        public int Length;
+
+        public override string ToString()
+        {
+            return ID.ToString();
+        }
+    }
+}

--- a/src/Blu4Net/Channel/BluChannel.cs
+++ b/src/Blu4Net/Channel/BluChannel.cs
@@ -360,7 +360,7 @@ namespace Blu4Net.Channel
             return response;
         }
 
-        public async Task<PresetLoadedResponse> LoadPreset(int id)
+        public async Task<LoadedResponse> LoadPreset(int id)
         {
             var parameters = HttpUtility.ParseQueryString(string.Empty);
             parameters["id"] = id.ToString();
@@ -368,11 +368,32 @@ namespace Blu4Net.Channel
             var document = await SendRequest("Preset", parameters).ConfigureAwait(false);
             if (document.Root.Name == "loaded")
             {
-                return document.Deserialize<PlaylistPresetLoadedResponse>();
+                return document.Deserialize<PlaylistLoadedResponse>();
             }
             if (document.Root.Name == "state")
             {
-                return document.Deserialize<StreamPresetLoadedResponse>();
+                return document.Deserialize<StreamLoadedResponse>();
+            }
+            throw new InvalidDataException();
+        }
+
+        public async Task<LoadedResponse> PlayURL(string playURL)
+        {
+            var parts = playURL.Split(new char[] { '?' });
+            var parameters = HttpUtility.ParseQueryString(parts[1]);
+
+            var document = await SendRequest(parts[0], parameters).ConfigureAwait(false);
+            if (document.Root.Name == "loaded")
+            {
+                return document.Deserialize<PlaylistLoadedResponse>();
+            }
+            else if (document.Root.Name == "state")
+            {
+                return document.Deserialize<StreamLoadedResponse>();
+            }
+            else if (document.Root.Name == "addsong")
+            {
+                return document.Deserialize<AddSongResponse>();
             }
             throw new InvalidDataException();
         }

--- a/src/Blu4Net/Channel/LoadedResponse.cs
+++ b/src/Blu4Net/Channel/LoadedResponse.cs
@@ -5,12 +5,12 @@ using System.Xml.Serialization;
 
 namespace Blu4Net.Channel
 {
-    public class PresetLoadedResponse
+    public class LoadedResponse
     {
     }
 
     [XmlRoot("loaded")]
-    public class PlaylistPresetLoadedResponse : PresetLoadedResponse
+    public class PlaylistLoadedResponse : LoadedResponse
     {
         [XmlAttribute("service")]
         public string Service;
@@ -25,7 +25,7 @@ namespace Blu4Net.Channel
     }
 
     [XmlRoot("state")]
-    public class StreamPresetLoadedResponse : PresetLoadedResponse
+    public class StreamLoadedResponse : LoadedResponse
     {
         [XmlText()]
         public string State;

--- a/src/Blu4Net/MusicBrowser.cs
+++ b/src/Blu4Net/MusicBrowser.cs
@@ -9,9 +9,19 @@ namespace Blu4Net
 {
     public class MusicBrowser : MusicContentNode
     {
+
+        private readonly BluChannel _channel;
+
         public MusicBrowser(BluChannel channel, BrowseContentResponse response)
             : base(channel, null, response)
         {
+            _channel = channel ?? throw new ArgumentNullException(nameof(channel));
         }
+
+        public Task PlayURL(string playURL)
+        {
+            return _channel.PlayURL(playURL);
+        }
+
     }
 }


### PR DESCRIPTION
Added PlayURL() to the MusicBrowser so you can play the url which the music-browser returns. Renamed PresetLoadedResponse to LoadedResponse, because playing something from the music-browser can give the same 'loaded-responses'. Added an AddsongResponse which is another result when you fire the playURL returned from the music-browser.