### PR TITLE
Added a way to set and update the CultureInfo. 

### DIFF
--- a/src/Blu4Net/BluPlayer.cs
+++ b/src/Blu4Net/BluPlayer.cs
@@ -1,6 +1,7 @@
 ﻿using Blu4Net.Channel;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -74,12 +75,17 @@ namespace Blu4Net
                 .Select(response => new PlayPosition(response));
         }
 
-        public static async Task<BluPlayer> Connect(Uri endpoint)
+        public static async Task<BluPlayer> Connect(Uri endpoint, CultureInfo acceptLanguage = null)
         {
             if (endpoint == null)
                 throw new ArgumentNullException(nameof(endpoint));
-            
-            var channel = new BluChannel(endpoint);
+
+            if (acceptLanguage == null)
+            {
+                acceptLanguage = new CultureInfo("en-US");
+            }
+
+            var channel = new BluChannel(endpoint, acceptLanguage);
             var syncStatus = await channel.GetSyncStatus().ConfigureAwait(false);
             var status = await channel.GetStatus().ConfigureAwait(false);
             var content = await channel.BrowseContent().ConfigureAwait(false);
@@ -87,22 +93,22 @@ namespace Blu4Net
             return new BluPlayer(channel, syncStatus, status, content);
         }
 
-        public static Task<BluPlayer> Connect(IPAddress address, int port = 11000)
+        public static Task<BluPlayer> Connect(IPAddress address, int port = 11000, CultureInfo acceptLanguage = null)
         {
             if (address == null)
                 throw new ArgumentNullException(nameof(address));
 
             var endpoint = new UriBuilder("http", address.ToString(), port).Uri;
-            return Connect(endpoint);
+            return Connect(endpoint, acceptLanguage);
         }
 
-        public static Task<BluPlayer> Connect(string host, int port = 11000)
+        public static Task<BluPlayer> Connect(string host, int port = 11000, CultureInfo acceptLanguage = null)
         {
             if (host == null)
                 throw new ArgumentNullException(nameof(host));
 
             var endpoint = new UriBuilder("http", host, port).Uri;
-            return Connect(endpoint);
+            return Connect(endpoint, acceptLanguage);
         }
 
         public TextWriter Log
@@ -234,6 +240,11 @@ namespace Blu4Net
                 return notifaction.Text;
             }
             return null;
+        }
+
+        public void UpdateAcceptLanguage(CultureInfo culture)
+        {
+            _channel.AcceptLanguage = culture;
         }
 
         public override string ToString()

--- a/src/Blu4Net/Channel/BluChannel.cs
+++ b/src/Blu4Net/Channel/BluChannel.cs
@@ -25,15 +25,17 @@ namespace Blu4Net.Channel
         public Uri Endpoint { get; }
         public TimeSpan Timeout { get; } = TimeSpan.FromSeconds(30);
         public TimeSpan RetryDelay { get; } = TimeSpan.FromSeconds(5);
-        public CultureInfo AcceptLanguage { get; } = new CultureInfo("en-US");
+        public CultureInfo AcceptLanguage { get; set; }
         public TextWriter Log { get; set; }
         public IObservable<StatusResponse> StatusChanges { get; }
         public IObservable<SyncStatusResponse> SyncStatusChanges { get; }
         public IObservable<VolumeResponse> VolumeChanges { get; }
 
-        public BluChannel(Uri endpoint)
+        public BluChannel(Uri endpoint, CultureInfo acceptLanguage)
         {
             Endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
+
+            AcceptLanguage = acceptLanguage ?? throw new ArgumentNullException(nameof(acceptLanguage));
 
             // recommended long polling interval for Status is 100 seconds
             StatusChanges = LongPolling<StatusResponse>("Status", 100).Retry(RetryDelay).Publish().RefCount();

--- a/tests/ChannelTests/ChannelTests.cs
+++ b/tests/ChannelTests/ChannelTests.cs
@@ -22,7 +22,7 @@ namespace ChannelTests
         public static async Task Initialize(TestContext context)
         {
             var enpoint = await BluEnvironment.ResolveEndpoints().FirstAsync();
-            Channel = new BluChannel(enpoint);
+            Channel = new BluChannel(enpoint, new CultureInfo("en-US"));
             Channel.Log = new DelegateTextWriter((message => context.WriteLine(message)));
         }
 


### PR DESCRIPTION
Added a way to set and update the CultureInfo in the BluPlayer, this will be transfered to the Channel. And this will be used in every call (this was already in there):
`client.DefaultRequestHeaders.AcceptLanguage.TryParseAdd(AcceptLanguage.Name);`

 For example in case of getting a contextMenu, this matters (example response, in dutch):

```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<browse sid="30" searchKey="Tidal:Search" serviceIcon="/Sources/images/TidalIcon.png" serviceName="TIDAL" service="Tidal" type="contextMenu">
<item text="Verwijder van favorieten" type="favourite-delete" actionURL="/DeleteFavourite?service=Tidal&amp;albumid=330930029"/>
<item text="Speel nu af" type="add-now" actionURL="/Add?service=Tidal&amp;playnow=1&amp;clear=0&amp;where=nextAlbum&amp;albumid=330930029"/>
<item text="Shuffle" type="add-shuffle" actionURL="/Add?service=Tidal&amp;playnow=1&amp;shuffle=1&amp;where=nextAlbum&amp;albumid=330930029"/>
<item text="Als eerstvolgende toevoegen aan de afspeellijst" type="addAll-next" actionURL="/Add?service=Tidal&amp;playnow=-1&amp;where=nextAlbum&amp;albumid=330930029"/>
<item text="Voeg toe aan het eind van de afspeellijst" type="addAll-last" actionURL="/Add?service=Tidal&amp;playnow=-1&amp;where=last&amp;albumid=330930029"/>
</browse>
```