### PR TITLE
Handle new StatusResponse is_preset value

### DIFF
--- a/src/Blu4Net/Channel/StatusResponse.cs
+++ b/src/Blu4Net/Channel/StatusResponse.cs
@@ -84,7 +84,7 @@ namespace Blu4Net.Channel
         public string PresetsID;
 
         [XmlElement("is_preset")]
-        public int IsPreset;
+        public string IsPreset;
 
         [XmlElement("preset_name")]
         public string PresetName;


### PR DESCRIPTION
I updated a PULSE M this morning and noticed that...

...StatusResponse > is_preset was changed from int to bool. Better to parse it as a string, as it is not part of the spec.