### PR TITLE
Volume adjustment based on delta db.

### DIFF
--- a/src/Blu4Net/BluPlayer.cs
+++ b/src/Blu4Net/BluPlayer.cs
@@ -138,6 +138,12 @@ namespace Blu4Net
             return response.Volume;
         }
 
+        public async Task<int> AdjustVolumeDb(double delta_db)
+        {
+            var response = await _channel.AdjustVolumeDb(delta_db).ConfigureAwait(false);
+            return response.Volume;
+        }
+
         public async Task<int> Mute(bool on = true)
         {
             var response = await _channel.Mute(on ? 1 : 0).ConfigureAwait(false);

--- a/src/Blu4Net/Channel/BluChannel.cs
+++ b/src/Blu4Net/Channel/BluChannel.cs
@@ -282,6 +282,13 @@ namespace Blu4Net.Channel
             return await SendRequest<VolumeResponse>("Volume", parameters).ConfigureAwait(false);
         }
 
+        public async Task<VolumeResponse> AdjustVolumeDb(double delta_db)
+        {
+            var parameters = HttpUtility.ParseQueryString(string.Empty);
+            parameters["db"] = delta_db.ToString(CultureInfo.InvariantCulture);
+            return await SendRequest<VolumeResponse>("Volume", parameters).ConfigureAwait(false);
+        }
+
         public async Task<VolumeResponse> Mute(int mute = 1)
         {
             if (mute < 0 || mute > 1)

--- a/tests/ChannelTests/ChannelTests.cs
+++ b/tests/ChannelTests/ChannelTests.cs
@@ -190,6 +190,15 @@ namespace ChannelTests
         }
 
         [TestMethod]
+        public async Task Channel_AdjustVolumeDb()
+        {
+            var amount = -1;
+            var previous = await Channel.GetVolume();
+            var response = await Channel.AdjustVolumeDb(amount);
+            Assert.AreEqual(previous.Decibel + amount, response.Decibel);
+        }
+
+        [TestMethod]
         public async Task Channel_MuteOn()
         {
             var response = await Channel.Mute(1);

--- a/tests/PlayerTests/PlayerTests.cs
+++ b/tests/PlayerTests/PlayerTests.cs
@@ -51,6 +51,32 @@ namespace PlayerTests
         }
 
         [TestMethod]
+        public async Task Player_AdjustVolumeDb()
+        {
+            var previous = await Player.GetVolume();
+            try
+            {
+                var completion = new TaskCompletionSource<int>();
+
+                using (Player.VolumeChanges
+                    .Where(volume => volume.Percentage == previous.Percentage + 1)
+                    .Timeout(TimeSpan.FromSeconds(2))
+                    .Subscribe(volume =>
+                    {
+                        completion.SetResult(volume.Percentage);
+                    }))
+                {
+                    await Player.AdjustVolumeDb(-0.5f);
+                    await completion.Task;
+                };
+            }
+            finally
+            {
+                await Player.SetVolume(previous.Percentage);
+            }
+        }
+
+        [TestMethod]
         public async Task Player_ChangeState()
         {
             var state = await Player.GetState();


### PR DESCRIPTION
This PR introduces a way to adjust volume based on an amount of decimals.
This change offers client applications more precise controle over volume adjustments. Which may be needed in scenarios where the amplifier has Volume Limits set, influencing the the low and high bounds on which the volume percentage is calculated.