### PR TITLE
Skip- and Back-operations using Actions when needed.

### DIFF
--- a/src/Blu4Net/BluPlayer.cs
+++ b/src/Blu4Net/BluPlayer.cs
@@ -209,7 +209,7 @@ namespace Blu4Net
             }
             
             var backAction = status.Actions?.Items.FirstOrDefault(a => a.Name.Equals("back", StringComparison.OrdinalIgnoreCase));
-            if (backAction != null)            
+            if (backAction != null && !string.IsNullOrEmpty(backAction.Url))            
             {
                 await _channel.ActionURL(backAction.Url).ConfigureAwait(false);
             }
@@ -227,7 +227,7 @@ namespace Blu4Net
             }
             
             var skipAction = status.Actions?.Items.FirstOrDefault(a => a.Name.Equals("skip", StringComparison.OrdinalIgnoreCase));
-            if (skipAction != null)            
+            if (skipAction != null && !string.IsNullOrEmpty(skipAction.Url))            
             {
                 await _channel.ActionURL(skipAction.Url).ConfigureAwait(false);
             }

--- a/src/Blu4Net/BluPlayer.cs
+++ b/src/Blu4Net/BluPlayer.cs
@@ -207,6 +207,13 @@ namespace Blu4Net
                 var response = await _channel.Back().ConfigureAwait(false);
                 return response?.ID;
             }
+            
+            var backAction = status.Actions?.Items.FirstOrDefault(a => a.Name.Equals("back", StringComparison.OrdinalIgnoreCase));
+            if (backAction != null)            
+            {
+                await _channel.ActionURL(backAction.Url).ConfigureAwait(false);
+            }
+            
             return null;
         }
 
@@ -218,6 +225,13 @@ namespace Blu4Net
                 var response = await _channel.Skip().ConfigureAwait(false);
                 return response?.ID;
             }
+            
+            var skipAction = status.Actions?.Items.FirstOrDefault(a => a.Name.Equals("skip", StringComparison.OrdinalIgnoreCase));
+            if (skipAction != null)            
+            {
+                await _channel.ActionURL(skipAction.Url).ConfigureAwait(false);
+            }
+            
             return null;
         }
 

--- a/src/Blu4Net/Channel/BluChannel.cs
+++ b/src/Blu4Net/Channel/BluChannel.cs
@@ -71,16 +71,19 @@ namespace Blu4Net.Channel
 
                 using (var response = await client.GetAsync(requestUri, cancellationToken).ConfigureAwait(false))
                 using (var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                using (var streamReader = new StreamReader(stream))
                 {
-                    var document = XDocument.Load(stream);
+                    var responseContent = streamReader.ReadToEnd();
+                    using (TextReader tr = new StringReader(responseContent))
+                    {
+                        var document = XDocument.Load(tr);
 
-                    LogMessage($"Response: {document}");
-
+                        LogMessage($"Response: {document}");
 #if FILE_LOGGING
-                    document.Save(@$"D:\Temp\{Interlocked.Increment(ref counter)}.txt");
+                        document.Save(@$"D:\Temp\{Interlocked.Increment(ref counter)}.txt");
 #endif
-
-                    return document;
+                        return document;
+                    }
                 }
             }
         }


### PR DESCRIPTION
As per protocol specs, Skip and Back operations should use the relevant Action api's when a streaming source is active. 

Note that my NAD C389 returns an http 200 with empty body instead of XML content when invoking the Action api's, making these operations throw an XML parsing error after succesfully executing the operation. This appears not according to spec. (that's why this PR also contains a a minor change to response handling logic as to allow for some more convinient debugging). 
I'm ignoring these exceptions in my client code, but there might be better solutions for this?